### PR TITLE
Fix Draco decoding error in node example

### DIFF
--- a/simple-node-example/fetch-tiles.js
+++ b/simple-node-example/fetch-tiles.js
@@ -20,9 +20,13 @@ async function run() {
   });
 
   console.log("Fetching tileset...")
-  const tilesetJson = await load(tilesetUrl, Tiles3DLoader, {'3d-tiles': { loadGLTF: false }} );
+  const tilesetJson = await load(tilesetUrl, Tiles3DLoader);
   const tileset3d = new Tileset3D(tilesetJson, {
     throttleRequests: false,
+    loadGLTF: false,
+    loadOptions: {
+      '3d-tiles': { loadGLTF: false },
+    },
     maximumScreenSpaceError: screenSpaceError
   })
   console.log("Traversing....")


### PR DESCRIPTION
The `simple-node-example`  was failing to load tiles due to the following error:

```
A 3D tile failed to load: undefined DracoDecoderModule is not a function
```

One way to fix this would be to pass in the Draco decoder in the tileset constructor options. But since we don't need loadersGL to actually decode the glTF tiles for us, this PR instead just sets `loadGLTF: false`. This will keep the tiles draco encoded. These can then either be loaded into a viewer that supports Draco or post processed with a library like https://gltf-transform.dev/ to decode it.

Note that we need to pass `loadOptions` in order to tell LoadersGL to propagate the `loadGLTF: false` flag to the external tilesets it finds as it traverses the root tileset

```javascript
loadOptions: {
  '3d-tiles': { loadGLTF: false },
}
```